### PR TITLE
fix sp2word, as we set --add_dummy_prefix 1

### DIFF
--- a/scripts/sentencepiece_to_word_alignments.py
+++ b/scripts/sentencepiece_to_word_alignments.py
@@ -14,7 +14,9 @@ def convert(src_file, tgt_file):
     examples = zip(get_mapping(src_file), get_mapping(tgt_file), fileinput.input(files=["-"]))
     for src_map, tgt_map, line in examples:
         subword_alignments = {(int(a), int(b)) for a, b in (x.split("-") for x in line.split())}
-        word_alignments = {"{}-{}".format(src_map[a], tgt_map[b]) for a, b in subword_alignments}
+        # word_alignments = {"{}-{}".format(src_map[a], tgt_map[b]) for a, b in subword_alignments}
+        # As we set --add_dummy_prefix 1, we need to delete 1 to make sure we start from 0 rather than 1. 
+        word_alignments = {"{}-{}".format(src_map[a] - 1, tgt_map[b] - 1) for a, b in subword_alignments}
         yield word_alignments
 
 


### PR DESCRIPTION
As in the script ./preprocess/run.sh, we set spm option --add_dummy_prefix 1(also default in spm_train), which makes the resulting subword corpus contain '▁' at the beginning of each sentence, makes converted word alignment count from 1, which breaks the AER calculate for subword part. To fix this issue, we can simply **subtract 1 to counteract this effect**.
