### PR TITLE
Normalize non breaking spaces for Romanian>English training data

### DIFF
--- a/preprocess/roen-train.sh
+++ b/preprocess/roen-train.sh
@@ -48,6 +48,7 @@ ${MOSES_DIR}/scripts/tokenizer/tokenizer.perl -l en -no-escape < ${EUROPARL_DIR_
 
 # merge
 for direction in "src" "tgt"; do
-  cat ${DIR_NAME}/${prefix}.${direction} ${EUROPARL_DIR_NAME}/${prefix}.${direction} > ${prefix}.${direction}
+  # Additionally normalize non breaking spaces to normal spaces (https://github.com/lilt/alignment-scripts/issues/7)
+  cat ${DIR_NAME}/${prefix}.${direction} ${EUROPARL_DIR_NAME}/${prefix}.${direction} | sed 's/\xC2\xA0/ /g' > ${prefix}.${direction}
 done
 

--- a/preprocess/run.sh
+++ b/preprocess/run.sh
@@ -25,7 +25,6 @@ for ln_pair in "roen" "enfr" "deen"; do
               --split_by_unicode_script  1 \
               --split_by_whitespace      1 \
               --remove_extra_whitespaces 1 \
-              --add_dummy_prefix         0 \
               --normalization_rule_name  identity \
               --vocab_size               40000 \
               --character_coverage       1.0 \

--- a/scripts/create_fast_align_corpus.sh
+++ b/scripts/create_fast_align_corpus.sh
@@ -6,6 +6,6 @@ if (( $# != 3 )); then
   exit 1
 fi
 
-# paste with ~ as delimiter | remove empty source or target lines
-paste -d "~" $1 $2 | sed 's/~/ ||| /g' | sed -e '/^ |||/d' -e '/||| $/d' > ${3}
+# paste with tab as delimiter | remove empty source or target lines
+paste $1 $2 | sed -E 's/\t/ |||' | sed -e '/^ |||/d' -e '/||| $/d' > ${3}
 

--- a/scripts/fast_align.sh
+++ b/scripts/fast_align.sh
@@ -26,8 +26,8 @@ target_name=${2##*/}
 direction=$3
 
 # create format used for fastalign
-paste -d "~" ${source_path} ${target_path} | sed 's/~/ ||| /g' > ${source_name}_${target_name}
-paste -d "~" ${target_path} ${source_path} | sed 's/~/ ||| /g' > ${target_name}_${source_name}
+paste ${source_path} ${target_path} | sed -E 's/\t/ ||| /g' > ${source_name}_${target_name}
+paste ${target_path} ${source_path} | sed -E 's/\t/ ||| /g' > ${target_name}_${source_name}
 
 # remove lines which have an empty source or target
 sed -e '/^ |||/d' -e '/||| $/d' ${source_name}_${target_name} > ${source_name}_${target_name}.clean


### PR DESCRIPTION
Fixes https://github.com/lilt/alignment-scripts/issues/7.

Additionally, remove inconsistent command line argument to spm_train which appeared twice (`--add_dummy_prefix         1` appeared later and was used, I kept this option). Also use tab as a separator (instead of `~`) when preparing fastAlign data format.