### PR TITLE
Fix unterminated `s' command

### DIFF
--- a/scripts/create_fast_align_corpus.sh
+++ b/scripts/create_fast_align_corpus.sh
@@ -7,5 +7,5 @@ if (( $# != 3 )); then
 fi
 
 # paste with tab as delimiter | remove empty source or target lines
-paste $1 $2 | sed -E 's/\t/ |||' | sed -e '/^ |||/d' -e '/||| $/d' > ${3}
+paste $1 $2 | sed -E 's/\t/ ||| /g' | sed -e '/^ |||/d' -e '/||| $/d' > ${3}
 


### PR DESCRIPTION
Original version results in "sed: -e expression #1, char 9: unterminated `s' command"

sed (GNU sed) 4.4
Distributor ID:	Debian
Description:	Debian GNU/Linux 9.13 (stretch)
Release:	9.13

Fixes #9